### PR TITLE
Add coverage generation and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,19 +16,6 @@ endif()
 # Generate coverage
 option(GENERATE_COVERAGE "Generate coverage" OFF)
 
-# If the option is set to true or we're running a debug build, generate coverage
-if(GENERATE_COVERAGE OR BUILD_CICD OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        include(ProcessorCount)
-        ProcessorCount(N)
-
-        if(NOT N EQUAL 0)
-            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g --coverage -fprofile-arcs -ftest-coverage")
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g --coverage -fprofile-arcs -ftest-coverage")
-        endif()
-    endif()
-endif()
-
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -51,6 +38,20 @@ list(REMOVE_DUPLICATES HEADER_DIRS)
 
 # Add executable
 add_library(DeFunBobEngine ${SOURCES})
+
+# If the option is set to true or we're running a debug build, generate coverage
+if(GENERATE_COVERAGE OR BUILD_CICD OR CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        include(ProcessorCount)
+        ProcessorCount(N)
+
+        if(NOT N EQUAL 0)
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g --coverage -fprofile-arcs -ftest-coverage")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0 -g --coverage -fprofile-arcs -ftest-coverage")
+            target_link_libraries(DeFunBobEngine PRIVATE gcov)
+        endif()
+    endif()
+endif()
 
 # Include headers
 foreach(_headerDir ${HEADER_DIRS})

--- a/DEVELOPMENT_GUIDELINES.md
+++ b/DEVELOPMENT_GUIDELINES.md
@@ -9,6 +9,7 @@
   - [Commentaar](#commentaar)
   - [CMake-bestanden](#cmake-bestanden)
   - [Bouwproces](#bouwproces)
+  - [Testen](#testen)
   - [Git en Versiebeheer](#git-en-versiebeheer)
   - [Code Reviews](#code-reviews)
   - [Documentatie](#documentatie)
@@ -18,8 +19,8 @@
 Gebruik de Clang Formatter om code te formatteren volgens de `C++ Coding Style Guide` van `LLVM`. Hier zijn enkele basisregels:
 
 - Gebruik 4 spaties voor inspringing (geen tabbladen).
-- Gebruik PascalCase voor functie- en variabelennamen.
-- Gebruik snake_case voor bestandsnamen.
+- Gebruik `PascalCase` voor functie- en variabelennamen.
+- Gebruik `snake_case` voor bestandsnamen.
 - Plaats accolades op een nieuwe regel voor functies en klassen.
 - Voeg spaties toe rond operatoren (bijv. x = 5, niet x=5).
 - Beperk regellengte tot 80-100 tekens.
@@ -81,6 +82,17 @@ Daarnaast kan er ook gebruik worden gemaakt van extensies voor de IDE om de code
 - Zorg ervoor dat uw project zonder problemen kan worden gebouwd met behulp van het cmake- en make-commando.
 - Voeg testdoelen toe om [unit tests](https://cmake.org/cmake/help/book/mastering-cmake/chapter/Testing%20With%20CMake%20and%20CTest.html) uit te voeren in `tests/`.
 - Maak gebruik van Continuous Integration (CI) om automatische builds en tests te garanderen.
+
+## Testen
+
+- Schrijf unit tests waar mogelijk om de functionaliteit van de code te testen.
+  - Om unit test te schrijven, maak je gebruik van het [CTest](https://cmake.org/cmake/help/latest/manual/ctest.1.html) framework van [CMake](https://cmake.org/).
+  - Dit doe je door een testbestand aan te maken in `tests/`.
+  - Een testbestand bevat een `main` functie die de tests uitvoert.
+  - Een testbestand is succesvol als het programma eindigt met een exit code van `0`.
+- Voer unit tests uit met behulp van het `ctest` commando.
+
+_Voor het toevoegen van nieuwe tests hoeft er naast het aanmaken van de runnable geen extra configuratie te gebeuren. CMake zal automatisch de test detecteren en uitvoeren. Mochten er nieuwe requirements zijn voor het uitvoeren van de test, dan kunnen deze toegevoegd worden aan de `tests/CMakeLists.txt` file._
 
 ## Git en Versiebeheer
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,11 +2,55 @@ cmake_minimum_required(VERSION 3.27)
 
 project(DeFunBobEngine-Test)
 
-# Test the demo_test.cpp file
-add_executable(DemoTest demo_test.cpp)
+file(GLOB TEST_SOURCES *.cpp)
 
-add_test(NAME DemoTest COMMAND DemoTest)
+set(TEST_EXECUTABLES "")
 
-set(DemoPassRegex "Passed" "PASSED" "passed")
+foreach(_source ${TEST_SOURCES})
+    get_filename_component(_executable ${_source} NAME_WE)
+    list(APPEND TEST_EXECUTABLES ${_executable})
+endforeach()
 
-set_property(TEST DemoTest PROPERTY PASS_REGULAR_EXPRESSION ${DemoPassRegex})
+message(STATUS "Found tests: ${TEST_EXECUTABLES}")
+
+file(GLOB_RECURSE HEADER_LIST ${PROJECT_SOURCE_DIR}/../include/*.hpp)
+
+foreach(_headerFile ${HEADER_LIST})
+    get_filename_component(_dir ${_headerFile} PATH)
+    list(APPEND HEADER_DIRS ${_dir})
+endforeach()
+
+list(REMOVE_DUPLICATES HEADER_DIRS)
+
+foreach(TEST_EXECUTABLE ${TEST_EXECUTABLES})
+    add_executable(${TEST_EXECUTABLE} ${TEST_EXECUTABLE}.cpp)
+
+    foreach(_headerDir ${HEADER_DIRS})
+        target_include_directories(${TEST_EXECUTABLE} PUBLIC ${_headerDir})
+    endforeach()
+
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE DeFunBobEngine)
+
+    find_package(SDL2 CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE
+        $<TARGET_NAME_IF_EXISTS:SDL2::SDL2main>
+        $<IF:$<TARGET_EXISTS:SDL2::SDL2>,SDL2::SDL2,SDL2::SDL2-static>
+    )
+
+    find_package(sdl2-gfx CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE SDL2::SDL2_gfx)
+
+    find_package(SDL2_image CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_image::SDL2_image>,SDL2_image::SDL2_image,SDL2_image::SDL2_image-static>)
+
+    find_package(SDL2_mixer CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_mixer::SDL2_mixer>,SDL2_mixer::SDL2_mixer,SDL2_mixer::SDL2_mixer-static>)
+
+    find_package(SDL2_ttf CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_ttf::SDL2_ttf>,SDL2_ttf::SDL2_ttf,SDL2_ttf::SDL2_ttf-static>)
+
+    find_package(SDL2_net CONFIG REQUIRED)
+    target_link_libraries(${TEST_EXECUTABLE} PRIVATE $<IF:$<TARGET_EXISTS:SDL2_net::SDL2_net>,SDL2_net::SDL2_net,SDL2_net::SDL2_net-static>)
+
+    add_test(NAME ${TEST_EXECUTABLE} COMMAND ${TEST_EXECUTABLE})
+endforeach()


### PR DESCRIPTION
This pull request adds coverage generation and unit tests to the project. It includes changes to the CMake files to enable coverage generation when the `GENERATE_COVERAGE` option is set to true or when running a debug build. The unit tests are written using the CTest framework and are located in the `tests/` directory. The tests can be executed using the `ctest` command. This PR also includes updates to the `DeFunBobEngine-Test` project to build and link the unit tests.