### PR TITLE
Allow the engine to stop when the window quit button is pressed

### DIFF
--- a/include/facades/sdl2/facades/sdl_input_facade.hpp
+++ b/include/facades/sdl2/facades/sdl_input_facade.hpp
@@ -210,6 +210,8 @@ class SDLInputFacade : public IInputFacade
     /**
      * @brief Returns true while the user holds down the given action.
      *
+     * @note The 'quit' action is always true when the user is quitting the game, regardless of
+     * whether it is registered or not.
      * @return True if any action is being performed, false otherwise.
      */
     bool GetAction(const std::string &action) const override;

--- a/include/facades/sdl2/sdl_input.hpp
+++ b/include/facades/sdl2/sdl_input.hpp
@@ -18,7 +18,6 @@
 #ifndef DEFUNBOBENGINE_INPUT_HPP
 #define DEFUNBOBENGINE_INPUT_HPP
 
-#include "point.hpp"
 #include <SDL.h>
 #include <SDL_scancode.h>
 #include <SDL_stdinc.h>
@@ -133,6 +132,12 @@ class SDLInput
      */
     SDL_Point GetMousePosition() const;
 
+    /**
+     * @brief Check if the application should quit.
+     * @return true if the application should quit, false otherwise.
+     */
+    bool ShouldQuit() const;
+
   private:
     std::unordered_map<SDL_Scancode, bool>
         frameKeyState; ///< The current state of the keys that have changed this frame.
@@ -142,6 +147,7 @@ class SDLInput
     std::unordered_map<SDL_Scancode, bool> keyState;  ///< The current state of all keys.
     std::unordered_map<Uint8, bool> mouseButtonState; ///< The current state of all mouse buttons.
     SDL_Point mousePosition;                          ///< The current position of the mouse cursor.
+    bool shouldQuit = false;                          ///< Whether the application should quit.
 };
 
 #endif // DEFUNBOBENGINE_INPUT_HPP

--- a/src/facades/sdl2/facades/sdl_input_facade.cpp
+++ b/src/facades/sdl2/facades/sdl_input_facade.cpp
@@ -13,7 +13,6 @@
 #include "point.hpp"
 #include "sdl_input.hpp"
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <stdexcept>
 
@@ -236,6 +235,9 @@ bool SDLInputFacade::AnyActionUp() const
 
 bool SDLInputFacade::GetAction(const std::string &action) const
 {
+    if (action == "quit")
+        return input->ShouldQuit();
+
     if (keyActionMap.find(action) == keyActionMap.end() &&
         mouseActionMap.find(action) == mouseActionMap.end())
         throw std::runtime_error("Action not registered");

--- a/src/facades/sdl2/sdl_input.cpp
+++ b/src/facades/sdl2/sdl_input.cpp
@@ -10,7 +10,6 @@
  */
 
 #include "sdl_input.hpp"
-#include "point.hpp"
 
 SDLInput::SDLInput()
 {
@@ -52,6 +51,9 @@ void SDLInput::Update()
         case SDL_MOUSEMOTION:
             mousePosition.x = event.motion.x;
             mousePosition.y = event.motion.y;
+            break;
+        case SDL_QUIT:
+            shouldQuit = true;
             break;
         }
     }
@@ -163,3 +165,5 @@ bool SDLInput::IsAnyMouseButtonDown() const
 }
 
 SDL_Point SDLInput::GetMousePosition() const { return mousePosition; }
+
+bool SDLInput::ShouldQuit() const { return shouldQuit; }

--- a/src/project/core/engine.cpp
+++ b/src/project/core/engine.cpp
@@ -23,7 +23,7 @@
 #include "scene_manager.hpp"
 #include "sdl_input_facade.hpp"
 #include "time.hpp"
-#include <thread>
+#include <iostream>
 
 Engine *Engine::instancePtr = nullptr;
 
@@ -61,20 +61,22 @@ void Engine::Start()
         // Start of the frame
         Time::StartFrame();
 
-        // Game logic goes here
         Get<PhysicsManager>()->Step();
 
-        // TODO: Remove (Input manager required)
         Get<IInputFacade>()->Update();
+
         Get<SceneManager>()->Update(deltaTime);
+
         Get<BehaviourScriptManager>()->Update();
 
-        // Render stuff goes here
         graphicsFacade->ClearScreen();
         Get<RenderManager>()->Render();
 
         graphicsFacade->PresentScreen();
 
+        // Keep this at the end of the frame so the user can execute actions before the engine stops
+        if (Get<IInputFacade>()->GetAction("quit"))
+            Stop();
         // End of the frame
 
         // Calculate FPS


### PR DESCRIPTION
## Beschrijving

<!-- Beschrijf de veranderingen die je hebt gemaakt -->
Deze PR maakt het mogelijk om de window quit knop te gebruiken om de engine/game te stoppen.

## Gerelateerde issues/taken

<!--- Dit project gebruikt GitHub issues en ClickUp voor het bijhouden van taken. Geef hier aan welke issues/taken gerelateerd zijn aan deze pull request. Zorg voor links naar de issues/taken. -->
N.V.T.

## Definition of Done

<!--- Zorg ervoor dat de volgende punten zijn afgevinkt voordat je de pull request indient. -->

- [x] Het gebruik van extern toegankelijke functionaliteiten voor de gameontwikkelaar is gedocumenteerd in de [USAGE.md](/USAGE.md).
- [x] De code voldoet indien van toepassing aan de acceptatiecriteria van de issue/taak.
- [x] De code voldoet aan de code style van het project zoals beschreven in de [DEVELOPMENT_GUIDELINES.md](/DEVELOPMENT_GUIDELINES.md).
- [x] De code bevat documentatie zoals beschreven in de [DEVELOPMENT_GUIDELINES.md](/DEVELOPMENT_GUIDELINES.md).
- [x] Er zijn unit tests geschreven voor de code indien van toepassing.
- [x] De code is getest en slaagt voor alle bestaande en nieuwe unit tests.